### PR TITLE
Fixing resourcePath for atom 1.25.0

### DIFF
--- a/lib/model/remote-edit-editor.js
+++ b/lib/model/remote-edit-editor.js
@@ -6,9 +6,12 @@
  */
 let Editor, RemoteEditEditor;
 const path = require('path');
-const {
-	resourcePath
-} = atom.config;
+
+let resourcePath = atom.config.resourcePath;
+if (!resourcePath) {
+	resourcePath = atom.getLoadSettings().resourcePath;
+}
+
 try {
 	Editor = require(path.resolve(resourcePath, 'src', 'editor'));
 } catch (e) {


### PR DESCRIPTION
This is a quick fix for #4 and has been tested with atom 1.23.3 and 1.25.0. I have not tested, but should also work with older versions.