### PR TITLE
Feature: files view keyboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Show/hide remote-edit panel
 - <kbd>Alt+r o</kbd> -
 Show open (downloaded) remote files.
 
+- <kbd>Alt+r f</kbd> -
+Give focus to the remote-edit file browser. This allows you to navigate with
+keyboard (up/down/enter/backspace)
+
 
 ### shortcuts within _host selection_ dialog
 
@@ -42,12 +46,7 @@ Delete hosts or downloaded files. Usable when selecting hosts (_Browse_) or open
 * Check keybindings. They are now in the <kbd>Alt+r</kbd> range
 * Keyboard support in files-view, eg:
   * focus when opening files
-  * up/down to select files
-  * enter to open or enter directory
-  * backspace to parent directory
   * escape to close files-view
-  * mouse: single click selects file/dir
-  * mouse: double click opens file/dir
 
 
 ## Credits

--- a/keymaps/remote-edit.cson
+++ b/keymaps/remote-edit.cson
@@ -11,12 +11,14 @@
   'ctrl-cmd-b': 'remote-edit:browse'
   'ctrl-cmd-o': 'remote-edit:show-open-files'
   'ctrl-cmd-\\': 'remote-edit:toggle-files-view'
+  'ctrl-cmd-f': 'filesview:list-focus'
 
 '.platform-win32, .platform-linux':
   'alt-r b': 'remote-edit:browse'
   'alt-r o': 'remote-edit:show-open-files'
   'alt-r m': 'remote-edit:browse-more'
   'alt-r v': 'remote-edit:toggle-files-view'
+  'alt-r f': 'filesview:list-focus'
 
 '.open-files-view.select-list':
   'shift-d': 'openfilesview:delete'
@@ -34,5 +36,9 @@
 '.host-view':
   'tab': 'host-view:focus-next'
   'shift-tab': 'host-view:focus-previous'
+
 '.remote-edit-tree-views':
   'backspace': 'filesview:previous-folder'
+  'up': 'filesview:list-select-prev'
+  'down': 'filesview:list-select-next'
+  'enter': 'filesview:list-enter'

--- a/keymaps/remote-edit.cson
+++ b/keymaps/remote-edit.cson
@@ -10,7 +10,7 @@
 '.platform-darwin':
   'cmd-r b': 'remote-edit:browse'
   'cmd-r o': 'remote-edit:show-open-files'
-  'cmd-r \\': 'remote-edit:toggle-files-view'
+  'cmd-r v': 'remote-edit:toggle-files-view'
   'cmd-r f': 'filesview:list-focus'
   'cmd-r m': 'remote-edit:reveal-in-browser'
 

--- a/keymaps/remote-edit.cson
+++ b/keymaps/remote-edit.cson
@@ -8,10 +8,11 @@
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
 '.platform-darwin':
-  'ctrl-cmd-b': 'remote-edit:browse'
-  'ctrl-cmd-o': 'remote-edit:show-open-files'
-  'ctrl-cmd-\\': 'remote-edit:toggle-files-view'
-  'ctrl-cmd-f': 'filesview:list-focus'
+  'cmd-r b': 'remote-edit:browse'
+  'cmd-r o': 'remote-edit:show-open-files'
+  'cmd-r \\': 'remote-edit:toggle-files-view'
+  'cmd-r f': 'filesview:list-focus'
+  'cmd-r m': 'remote-edit:reveal-in-browser'
 
 '.platform-win32, .platform-linux':
   'alt-r b': 'remote-edit:browse'

--- a/keymaps/remote-edit.cson
+++ b/keymaps/remote-edit.cson
@@ -12,14 +12,14 @@
   'cmd-r o': 'remote-edit:show-open-files'
   'cmd-r v': 'remote-edit:toggle-files-view'
   'cmd-r f': 'filesview:list-focus'
-  'cmd-r m': 'remote-edit:reveal-in-browser'
+  'cmd-r m': 'remote-edit:browse-more'
 
 '.platform-win32, .platform-linux':
   'alt-r b': 'remote-edit:browse'
   'alt-r o': 'remote-edit:show-open-files'
-  'alt-r m': 'remote-edit:browse-more'
   'alt-r v': 'remote-edit:toggle-files-view'
   'alt-r f': 'filesview:list-focus'
+  'alt-r m': 'remote-edit:browse-more'
 
 '.open-files-view.select-list':
   'shift-d': 'openfilesview:delete'

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -101,6 +101,9 @@ module.exports =
 
     atom.commands.add('atom-workspace', 'remote-edit:show-open-files', => @showOpenFiles())
     atom.commands.add('atom-workspace', 'remote-edit:browse', => @browse())
+    # Browse more is a slight variation of remote-edit:reveal-in-browser
+    # The only difference is that if the current tab is not RemoteEditEditor
+    # it will open hosts-view
     atom.commands.add('atom-workspace', 'remote-edit:browse-more', => @browseMore())
     atom.commands.add('atom-workspace', 'remote-edit:new-sftp-host', => @newHost("sftp"))
     atom.commands.add('atom-workspace', 'remote-edit:new-ftp-host', => @newHost("ftp"))
@@ -130,9 +133,7 @@ module.exports =
   browseMore: ->
     editor = atom.workspace.getActiveTextEditor()
     if editor instanceof RemoteEditEditor
-      remdir = editor.localFile.remoteFile.dirName
-      atom.notifications.addSuccess("Re-opening: #{remdir} on #{editor.host.hostname}")
-      @createFilesView().setHost(editor.host, remdir)
+      @createFilesView().revealCurrentFile()
     else
       @browse()
 

--- a/lib/model/remote-edit-editor.js
+++ b/lib/model/remote-edit-editor.js
@@ -60,6 +60,12 @@ module.exports =
 				} else {
 					throw "No localFile in RemoteEditEditor constructor";
 				}
+
+				// This is here for consistency since sometimes the localFile.host
+				// is not set. Prefer using this.host instead
+				if (!this.localFile.host && params.host) {
+					this.localFile.host = params.host
+				}
 			}
 
 			getIconName() {

--- a/lib/model/sftp-host.coffee
+++ b/lib/model/sftp-host.coffee
@@ -101,6 +101,7 @@ module.exports =
       @connection?.end()
       callback?(null)
 
+
     connect: (callback, connectionOptions = {}) ->
       @emitter.emit 'info', {message: "Connecting to sftp://#{@username}@#{@hostname}:#{@port}", type: 'info'}
       async.waterfall([

--- a/lib/view/files-view.coffee
+++ b/lib/view/files-view.coffee
@@ -115,6 +115,7 @@ module.exports =
             callback(null)
         (callback) =>
           @openDirectory(dir, callback)
+          @list.focus()
       ], (err, result) =>
         if err?
           console.error err
@@ -368,7 +369,7 @@ module.exports =
 
         visible_area_start = parent.scrollTop();
         visible_area_end = visible_area_start + parent.innerHeight();
-        
+
         if (offset < visible_area_start)
              parent.scrollTop(offset);
              return false;

--- a/lib/view/files-view.coffee
+++ b/lib/view/files-view.coffee
@@ -223,7 +223,13 @@ module.exports =
       @host.lastOpenDirectory = @path
       @server_folder.html(@path)
 
+    # This is the "main" entry point for external components to interact with
+    # the left side panel
     setHost: (host, connect_path = false, callback) ->
+      # Ensure the panel is visible
+      @show()
+
+      # Avoid re-connecting if the hostname is the same
       if host.hostname == @host?.hostname
         if connect_path
           @openDirectory(connect_path, callback)
@@ -235,7 +241,6 @@ module.exports =
 
       @host?.close()
       @host = host
-      @show()
 
       # Extend the callers' callback with some basic post-connect functions
       @connect({}, connect_path, () =>

--- a/lib/view/files-view.coffee
+++ b/lib/view/files-view.coffee
@@ -41,7 +41,7 @@ module.exports =
           # @tag 'atom-text-editor', 'mini': true, class: 'native-key-bindings', outlet: 'filter'
           # Gettext does not exist cause there is no model behind this...
           @input class: 'remote-edit-filter-text native-key-bindings', tabindex: 1, outlet: 'filter'
-          @div class: 'remote-edit-file-scroller', =>
+          @div class: 'remote-edit-file-scroller', outlet: 'scroller', =>
             @ol class: 'list-tree full-menu focusable-panel', tabindex: -1, outlet: 'list'
         @div class: 'remote-edit-resize-handle', outlet: 'resizeHandle'
 
@@ -358,6 +358,27 @@ module.exports =
       @width(1) # Shrink to measure the minimum width of list
       @width(Math.max(@list.outerWidth(), @treeView.treeUI.outerWidth()+10))
 
+    scrollToView: (element, parent) ->
+        # element = $(element);
+        # parent = $(parent);
+
+        offset = element.offset().top - parent.offset().top + parent.scrollTop();
+        height = element.innerHeight();
+        offset_end = offset + height;
+
+        visible_area_start = parent.scrollTop();
+        visible_area_end = visible_area_start + parent.innerHeight();
+        
+        if (offset < visible_area_start)
+             parent.scrollTop(offset);
+             return false;
+        else if (offset_end > visible_area_end)
+            parent.scrollTop(parent.scrollTop() + offset_end - visible_area_end + 10);
+            return false;
+
+        return true;
+
+
     listSelectNext: =>
       item = @getSelectedItem()
       if item.next('li').length == 0
@@ -365,6 +386,7 @@ module.exports =
 
       @deselect()
       item.next('li').addClass('selected').data('select-list-item')
+      @scrollToView(@getSelectedItem(), @scroller)
 
     listSelectPrev: =>
       item = @getSelectedItem()
@@ -373,6 +395,7 @@ module.exports =
 
       @deselect()
       item.prev('li').addClass('selected').data('select-list-item')
+      @scrollToView(@getSelectedItem(), @scroller)
 
     listEnter: =>
       item = @getSelectedItem()

--- a/lib/view/hosts-view.coffee
+++ b/lib/view/hosts-view.coffee
@@ -80,9 +80,6 @@ module.exports =
       @cancel()
       filesView = module.parent.exports.createFilesView()
       filesView.setHost(item)
-      # filesView.host = item
-      # filesView.connect()
-      # filesView.show()
 
     listenForEvents: ->
       @disposables.add atom.commands.add 'atom-workspace', 'hostview:delete', =>

--- a/lib/view/tree-view.coffee
+++ b/lib/view/tree-view.coffee
@@ -305,13 +305,7 @@ module.exports =
           host = tmpNode.meta.host
 
         if folder
-          @filesView.setHost(host)
-
-          # Select the file after the connection
-          @filesView.openDirectory(folder, () =>
-            if file
-              @filesView.selectItemByPath(file)
-          )
+          @filesView.revealFile(host, folder, file)
 
 
 

--- a/lib/view/tree-view.coffee
+++ b/lib/view/tree-view.coffee
@@ -286,7 +286,6 @@ module.exports =
           folder = node.meta.remoteFile.dirName
           file = node.meta.remoteFile.path
         else
-
           folder = "/"
           if node.isFolder
             folder = @rightClickNode.data('node-path')

--- a/styles/remote-edit.less
+++ b/styles/remote-edit.less
@@ -218,20 +218,21 @@
         content: "\f078";
     }
 
-    // highlight on select
-    .list-entries li::before {
-        content: '';
-        position: absolute;
-        margin-top: -2px;
-        left: 0;
-        right: 0;
-        height: 25px;
-        z-index: -1;
-    }
-
-    .list-entries li.selected::before {
-        background-color: #2c313a;
-    }
+    // NOTE: :'( Cannot figure this one out
+    // // highlight on select
+    // .list-entries li::before {
+    //     content: '';
+    //     position: absolute;
+    //     margin-top: -2px;
+    //     left: 0;
+    //     right: 0;
+    //     height: 25px;
+    //     z-index: -1;
+    // }
+    //
+    // .list-entries li.selected::before {
+    //     background-color: #2c313a;
+    // }
 }
 
 .remote-edit-panel-toggle {

--- a/styles/remote-edit.less
+++ b/styles/remote-edit.less
@@ -94,6 +94,12 @@
   height: 100%;
 }
 
+
+
+.list-tree:focus li.selected::before {
+    background-color: #4d78cc;
+}
+
 .remote-edit-tree-views .list-tree {
   flex-grow: 1;
   flex-shrink: 0;

--- a/styles/remote-edit.less
+++ b/styles/remote-edit.less
@@ -159,13 +159,14 @@
         padding: 0;
         list-style: none;
         cursor: default;
+        position: static;
     }
 
     // First level items...
     .list-entries li {
         padding-left: 8px;
         white-space: nowrap;
-        position: relative;
+        position: static;
     }
 
     // All other level folders
@@ -200,6 +201,7 @@
         width: 12px;
         height: 12px;
         content: "\f0a3";
+        display: inline-block;
     }
 
     // Collapsed folder
@@ -210,20 +212,20 @@
         content: "\f078";
     }
 
-    // // TODO: FIXME: The following never worked... weird behaviour
-    // .list-entries li::before {
-    //     content: '';
-    //     position: absolute;
-    //     margin-top: -2px;
-    //     left: 0;
-    //     right: 0;
-    //     height: 25px;
-    //     z-index: -1;
-    // }
-    //
-    // .list-entries li.selected::before {
-    //     background-color: #2c313a;
-    // }
+    // highlight on select
+    .list-entries li::before {
+        content: '';
+        position: absolute;
+        margin-top: -2px;
+        left: 0;
+        right: 0;
+        height: 25px;
+        z-index: -1;
+    }
+
+    .list-entries li.selected::before {
+        background-color: #2c313a;
+    }
 }
 
 .remote-edit-panel-toggle {


### PR DESCRIPTION
Last one from me for a while :)

- Enables up, down, enter and backspace within the files-view
- Introduces `Alt+r f` for giving focus to the files-view (usually from the main edit pane)
- Fixes file selection CSS issue in tree-view
- Merges `openDirectory` and `populate` methods of files-view. The first was a thin wrapper of the second one. Now there is only one method (`openDirectory`)

Has been briefly testes in atom 1.23.3 and 1.25.0