### PR TITLE
Feature: tree view resize support

### DIFF
--- a/lib/view/files-view.coffee
+++ b/lib/view/files-view.coffee
@@ -366,6 +366,19 @@ module.exports =
       $(document).off('mousemove', @resizeTreeView)
       $(document).off('mouseup', @resizeStopped)
 
+    resizeVerticalStarted: =>
+      $(document).on('mousemove', @resizeVerticalTreeView)
+      $(document).on('mouseup', @resizeVerticalStopped)
+
+    resizeVerticalStopped: =>
+      $(document).off('mousemove', @resizeVerticalTreeView)
+      $(document).off('mouseup', @resizeVerticalTreeView)
+
+    resizeVerticalTreeView: (e) =>
+      return @resizeVerticalStopped() unless e.which is 1
+      console.log("Setting height to " + e.offsetY )
+      @treeView.setHeight(e.pageY)
+
     resizeTreeView: ({pageX, which}) =>
       return @resizeStopped() unless which is 1
       width = pageX - @offset().left
@@ -394,27 +407,35 @@ module.exports =
       @on 'mousedown', '.remote-edit-resize-handle', (e) =>
         @resizeStarted(e)
 
+      @on 'mousedown', '.remote-edit-panel-toggle', (e) =>
+        @resizeVerticalStarted(e)
+
       @on 'mousedown', '.remote-edit-panel-toggle .after', (e) =>
-        if e.which != 1
-          e.preventDefault()
-          false
-        @listHidable.addClass("hidden")
-        @treeView.removeClass("hidden")
+        if e.which == 1
+          @listHidable.addClass("hidden")
+          @treeView.removeClass("hidden")
+          @treeView.resetHeight()
+
+        e.preventDefault()
+        false
 
       @on 'mousedown', '.remote-edit-panel-toggle .before', (e) =>
-        if e.which != 1
-          e.preventDefault()
-          false
-        @listHidable.removeClass("hidden")
-        @treeView.addClass("hidden")
+        if e.which == 1
+          @listHidable.removeClass("hidden")
+          @treeView.addClass("hidden")
+          @treeView.resetHeight()
+
+        e.preventDefault()
+        false
 
       @on 'mousedown', '.remote-edit-panel-toggle .middle', (e) =>
-        if e.which != 1
-          e.preventDefault()
-          false
+        if e.which == 1
+          @listHidable.removeClass("hidden")
+          @treeView.removeClass("hidden")
+          @treeView.resetHeight()
 
-        @listHidable.removeClass("hidden")
-        @treeView.removeClass("hidden")
+        e.preventDefault()
+        false
 
       @filter.on "keyup", (e) =>
         @doFilter(e)

--- a/lib/view/tree-view.coffee
+++ b/lib/view/tree-view.coffee
@@ -26,6 +26,24 @@ module.exports =
           @div class: 'remote-edit-treeview-list', =>
             @ol class: 'list-entries full-menu focusable-panel', tabindex: -1, outlet: 'treeUI'
 
+
+    # Set the height of this view. Usually this view is flex with 100% height
+    # sharing space with browser. Once you call this function, flex is removed
+    # and explicit height is set (in px)
+    setHeight: (height) =>
+      height = height + ""
+      if height.indexOf("px") == -1
+        height += "px"
+      $('.remote-edit-opened-tree').css({'max-height': height})
+      $('.remote-edit-opened-tree').css({'flex-grow': 0, 'flex-basis': 'auto'})
+
+    # This method will reset any height settings and put the component back to
+    # flex mode
+    resetHeight: (height) =>
+      $('.remote-edit-opened-tree').css({'max-height': ''})
+      $('.remote-edit-opened-tree').css({'flex-grow': 1, 'flex-basis': '0%'})
+
+
     splitPathParts: (localFile) ->
       # explode paths
       pathParts = localFile.remoteFile.path.split(Path.sep)


### PR DESCRIPTION
This one seemed like a quick-win - minor changes allowing one to resize the left hand panels by clicking on the separator. Resize will not work if the click target is any of the "buttons" but it will in-between them.