### PR TITLE
Fix readme for macos shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,16 @@ This version integrates the work of @urban-1 and @newinnovations.
 
 ## Main keyboard shortcuts
 
-- <kbd>Alt+r b</kbd> -
+- <kbd>Alt+r b</kbd>/<kbd>&#8984;+r b</kbd> -
 Select remote host and start browsing in / or last directory (when selected in preferences).
 
-- <kbd>Alt+r m</kbd> -
+- <kbd>Alt+r m</kbd>/<kbd>&#8984;+r m</kbd> -
 Browse remote host in directory of the current editor tab.
 
--   <kbd>Alt+r v</kbd> -
+-   <kbd>Alt+r v</kbd>/<kbd>&#8984;+r v</kbd> -
 Show/hide remote-edit panel
 
-- <kbd>Alt+r o</kbd> -
+- <kbd>Alt+r o</kbd>/<kbd>&#8984;+r o</kbd> -
 Show open (downloaded) remote files.
 
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Show/hide remote-edit panel
 - <kbd>Alt+r o</kbd>/<kbd>&#8984;+r o</kbd> -
 Show open (downloaded) remote files.
 
-- <kbd>Alt+r f</kbd> -
+- <kbd>Alt+r f</kbd><kbd>&#8984;+r f</kbd> -
 Give focus to the remote-edit file browser. This allows you to navigate with
 keyboard (up/down/enter/backspace)
 


### PR DESCRIPTION
Fixes  #10: Adding MacOS keyboard shortcuts next to the Windows/Linux ones 