### PR TITLE
[fix] Password field CSS hack to hide typed characters

### DIFF
--- a/styles/remote-edit.less
+++ b/styles/remote-edit.less
@@ -304,10 +304,16 @@ atom-text-editor.editor .password-lines .line {
     left: 0px;
     top: 0px;
     color: @text-color !important;
+    background-color: @input-background-color !important;
   }
+
   span.text {
     color:rgba(0, 0, 0, 0);
   }
+}
+
+atom-text-editor.editor.is-focused .password-lines .line span.syntax--text:before {
+    background-color: @app-background-color !important;
 }
 
 .remote-edit-info {


### PR DESCRIPTION
I had introduced a CSS hack borrowed from https://discuss.atom.io/t/password-fields-when-using-editorview-subview/11061/8 which emulates password fields - something that back then was not supported by atom views. This is only for on-screen "security" so your password cannot be read while being entered.

People have noticed that in the latest release the star characters are appearing on top of the password characters allowing someone to figure out what the underlying text is... This is being fixed in this PR with CSS `background-color` 

Before:
![pwd-old](https://user-images.githubusercontent.com/796204/38834387-3f1a2a5e-41c0-11e8-8917-0a37d07a6a29.png)

After:
![pwd-new](https://user-images.githubusercontent.com/796204/38834406-4f9edf64-41c0-11e8-855b-3b53c640a0a9.png)

