### PR TITLE
[fix] Adding RemoteEditEditor copy()

### DIFF
--- a/lib/model/remote-edit-editor.js
+++ b/lib/model/remote-edit-editor.js
@@ -41,7 +41,13 @@ module.exports =
 				if (params == null) {
 					params = {};
 				}
+
 				super(params);
+
+				// Store our original parameters. These are used later on to
+				// initialize a cloned RemoteEditEditor in `copy()`
+				this.remoteEditParams = params;
+
 				if (params.host) {
 					this.host = params.host;
 				} else if (params.reHost) {
@@ -66,6 +72,10 @@ module.exports =
 				if (!this.localFile.host && params.host) {
 					this.localFile.host = params.host
 				}
+			}
+
+			copy() {
+				return new RemoteEditEditor(this.remoteEditParams)
 			}
 
 			destroy () {


### PR DESCRIPTION
This seems to be fixing save in split file (#16). What happens is:

- `split()` is a method that belongs to `panel.js`
- `panel.split` will call `copy()` for all items in the panel
- `copy()` was missing from RemoteEditEditor and thus the parent one was called (creating a simple editor that save the local file only)

I have added the `copy()` method now which just calls the constructor to return a new RemoteEditEditor with the same parameters