### PR TITLE
[fix] Host config comparison method 

### DIFF
--- a/lib/model/host.coffee
+++ b/lib/model/host.coffee
@@ -38,6 +38,13 @@ module.exports =
       toReturn = "#{toReturn} #{@port}" if searchKeySettings["port"]
       return toReturn
 
+    # Compare this host to the given one and return true if it is the same
+    # host/configuration. Atm checking hostname, username and port
+    equals: (host) ->
+      return (@hostname == host.hostname && \
+              @username == host.username && \
+              @port == host.port)
+
     getServiceAccount: ->
       "#{@username}@#{@hostname}:#{@port}"
 

--- a/lib/view/files-view.coffee
+++ b/lib/view/files-view.coffee
@@ -234,7 +234,7 @@ module.exports =
       @show()
 
       # Avoid re-connecting if the hostname is the same
-      if host.hostname == @host?.hostname
+      if @host?.equals(host)
         if connect_path
           @openDirectory(connect_path, callback)
         else


### PR DESCRIPTION
Fixing #20: On re-connect, we are checking if we are already connected. This comparison was based solely on the remote hostname. As a result, connecting to the same host with a different username was impossible.

This commit/branch adds a `host.equals()` method which compares host configurations using all remote hostname, username and port.

Tested locally with a mock user