### PR TITLE
Feature keyboard interactive

### DIFF
--- a/lib/model/sftp-host.coffee
+++ b/lib/model/sftp-host.coffee
@@ -151,7 +151,10 @@ module.exports =
             # console.log(prompts)
             async.waterfall([
               (callback) ->
-                passwordDialog = new Dialog({prompt: "Enter passcode or passphrase"})
+                passwordDialog = new Dialog({
+                  prompt: "Keyboard Interactive Auth",
+                  detail: prompts[0].prompt.replace(/(?:\r\n|\r|\n)/g, '<br>')
+                })
                 passwordDialog.toggle(callback)
             ], (err, result) =>
               if err?

--- a/lib/model/sftp-host.coffee
+++ b/lib/model/sftp-host.coffee
@@ -115,10 +115,6 @@ module.exports =
       @connection = null
       callback?(null)
 
-    # Receiver for debug messages from ssh2 lib
-    _debugSsh: (str) ->
-      console.debug(str)
-
     connect: (callback, connectionOptions = {}) ->
       @emitter.emit 'info', {message: "Connecting to sftp://#{@username}@#{@hostname}:#{@port}", type: 'info'}
       async.waterfall([

--- a/lib/model/sftp-host.coffee
+++ b/lib/model/sftp-host.coffee
@@ -28,12 +28,22 @@ module.exports =
     connection: undefined
     protocol: "sftp"
 
-    constructor: (@alias = null, @hostname, @directory, @username, @port = "22", @localFiles = [], @usePassword = false, @useAgent = true, @usePrivateKey = false, @password, @passphrase, @privateKeyPath, @lastOpenDirectory) ->
+    constructor: (@alias = null, @hostname, @directory, @username, @port = "22", @localFiles = [], @useKeyboard = false, @usePassword = false, @useAgent = true, @usePrivateKey = false, @password, @passphrase, @privateKeyPath, @lastOpenDirectory) ->
       # Default to /home/<username> which is the most common case...
       if @directory == ""
         @directory = "/home/#{@username}"
 
       super( @alias, @hostname, @directory, @username, @port, @localFiles, @usePassword, @lastOpenDirectory)
+
+    getConnectionStringUsingKbdInteractive: ->
+      {
+        host: @hostname,
+        port: @port,
+        username: @username,
+        tryKeyboard: true
+      }
+
+
 
     getConnectionStringUsingAgent: ->
       connectionString =  {
@@ -94,6 +104,8 @@ module.exports =
         return _.extend(@getConnectionStringUsingKey(), connectionOptions)
       else if @usePassword
         return _.extend(@getConnectionStringUsingPassword(), connectionOptions)
+      else if @useKeyboard
+        return _.extend(@getConnectionStringUsingKbdInteractive(), connectionOptions)
       else
         throw new Error("No valid connection method is set for SftpHost!")
 
@@ -209,6 +221,7 @@ module.exports =
         @username
         @port
         localFiles: localFile.serialize() for localFile in @localFiles
+        @useKeyboard
         @useAgent
         @usePrivateKey
         @usePassword

--- a/lib/view/dialog.coffee
+++ b/lib/view/dialog.coffee
@@ -7,10 +7,11 @@ class Dialog extends View
   @content: ({prompt, @type} = {}) ->
     @div class: 'dialog', =>
       @label prompt, class: 'icon', outlet: 'promptText'
+      @p class: 'hidden', outlet: 'promptDetail'
       @subview 'miniEditor', new TextEditorView(mini: true)
       @div class: 'error-message', outlet: 'errorMessage'
 
-  initialize: ({@prompt, iconClass, @type} = {}) ->
+  initialize: ({@prompt, iconClass, @type, @detail} = {}) ->
     @promptText.addClass(iconClass) if iconClass
 
     @disposables = new CompositeDisposable
@@ -25,6 +26,10 @@ class Dialog extends View
 
     if @type == "password"
       Passwd.maskPass(@miniEditor)
+
+    if @detail
+      @promptDetail.html(@detail)
+      @promptDetail.removeClass('hidden')
 
   onConfirm: (value) ->
     @callback?(undefined, value)

--- a/lib/view/host-view.coffee
+++ b/lib/view/host-view.coffee
@@ -233,7 +233,7 @@ module.exports =
           @privateKeyButton.click()
         else if @host.useAgent
           @userAgentButton.click()
-        else if @host.useKeyboard
+        if @host.useKeyboard
           @kbdInteractiveButton.click()
       else if (@host instanceof FtpHost)
         @authenticationButtonsBlock.hide()

--- a/lib/view/host-view.coffee
+++ b/lib/view/host-view.coffee
@@ -102,6 +102,7 @@ module.exports =
 
       # hack
       Passwd.maskPass(@password)
+      Passwd.maskPass(@privateKeyPassphrase)
 
     focusNext: =>
       elements = [@hostname, @directory, @username, @port, @alias, @saveButton]
@@ -145,7 +146,7 @@ module.exports =
       @password.focus()
 
     kbdInteractiveButtonClick: ->
-      @kbdInteractiveButton.toggleClass('selected', true)
+      @kbdInteractiveButton.toggleClass('selected')
 
 
 

--- a/lib/view/host-view.coffee
+++ b/lib/view/host-view.coffee
@@ -145,10 +145,7 @@ module.exports =
       @password.focus()
 
     kbdInteractiveButtonClick: ->
-      @authenticationButtonsBlock.find('.btn').toggleClass('selected', false)
       @kbdInteractiveButton.toggleClass('selected', true)
-      @privateKeyBlock.hide()
-      @passwordBlock.hide()
 
 
 

--- a/lib/view/host-view.coffee
+++ b/lib/view/host-view.coffee
@@ -39,14 +39,15 @@ module.exports =
             @button class: 'btn selected', outlet: 'userAgentButton', click: 'userAgentButtonClick', 'User agent'
             @button class: 'btn', outlet: 'privateKeyButton', click: 'privateKeyButtonClick', 'Private key'
             @button class: 'btn', outlet: 'passwordButton', click: 'passwordButtonClick', 'Password'
+            @button class: 'btn', outlet: 'kbdInteractiveButton', click: 'kbdInteractiveButtonClick', 'Keyboard Interactive'
 
-        @div class: 'block', outlet: 'passwordBlock', =>
+        @div class: 'block auth-details', outlet: 'passwordBlock', =>
           @label 'Password:'
           @subview 'password', new TextEditorView(mini: true)
           @label 'Passwords are by default stored in cleartext! Leave password field empty if you want to be prompted.', class: 'text-warning'
           @label 'Passwords can be saved to default system keychain by enabling option in settings.', class: 'text-warning'
 
-        @div class: 'block', outlet: 'privateKeyBlock', =>
+        @div class: 'block auth-details', outlet: 'privateKeyBlock', =>
           @label 'Private key path:'
           @subview 'privateKeyPath', new TextEditorView(mini: true)
           @label 'Private key passphrase:'
@@ -143,6 +144,13 @@ module.exports =
       @passwordBlock.show()
       @password.focus()
 
+    kbdInteractiveButtonClick: ->
+      @authenticationButtonsBlock.find('.btn').toggleClass('selected', false)
+      @kbdInteractiveButton.toggleClass('selected', true)
+      @privateKeyBlock.hide()
+      @passwordBlock.hide()
+
+
 
     confirm: ->
       @cancel()
@@ -157,6 +165,7 @@ module.exports =
         @host.useAgent = @userAgentButton.hasClass('selected')
         @host.usePrivateKey = @privateKeyButton.hasClass('selected')
         @host.usePassword = @passwordButton.hasClass('selected')
+        @host.useKeyboard = @kbdInteractiveButton.hasClass('selected')
 
         if @privateKeyButton.hasClass('selected')
           @host.privateKeyPath = fs.absolute(@privateKeyPath.getText())
@@ -226,6 +235,8 @@ module.exports =
           @privateKeyButton.click()
         else if @host.useAgent
           @userAgentButton.click()
+        else if @host.useKeyboard
+          @kbdInteractiveButton.click()
       else if (@host instanceof FtpHost)
         @authenticationButtonsBlock.hide()
         @passwordBlock.show()

--- a/lib/view/hosts-view.coffee
+++ b/lib/view/hosts-view.coffee
@@ -65,6 +65,8 @@ module.exports =
               authType = "key"
             else if item.useAgent
               authType = "agent"
+            else if item.useKeyboard
+              authType = "keyboard"
             @div class: "secondary-line", "Type: SFTP, Open files: #{item.localFiles.length}, Auth: " + authType
           else if item instanceof FtpHost
             authType = "not set"

--- a/styles/remote-edit.less
+++ b/styles/remote-edit.less
@@ -313,7 +313,7 @@ atom-text-editor.editor .password-lines .line {
 }
 
 atom-text-editor.editor.is-focused .password-lines .line span.syntax--text:before {
-    background-color: @app-background-color !important;
+    background-color:  @input-background-color-focus !important;
 }
 
 .remote-edit-info {


### PR DESCRIPTION
Hi @newinnovations 

How are things?

I recently needed 'keyboard-interactive' auth method which was not supported by our plugin. This PR adds it allowing the user to enter a 2FA token on login.

The changes in summary are:

-  Adds an optional `details` field in the generic `Dialog` which is used to display the servers' prompt message
-  Adds another authentication option which can be used in conjunction with the three auth methods already supported
-  Minor CSS color fix for password fields
-  Enables password masking for private key passphrase which was previously clear text

