### PR TITLE
[fix] Improve reliability attempt 1 :)

### DIFF
--- a/lib/model/remote-edit-editor.js
+++ b/lib/model/remote-edit-editor.js
@@ -125,13 +125,27 @@ module.exports =
 			}
 
 			save() {
-				this.buffer.save().then(function(result) {
-					this.initiateUpload().then(function() {
-						this.emitter.emit('saved');
-						if (atom.config.get('remote-edit-ni.uploadOptions.closeOnUpload'))
-							this.host.close();
-					}.bind(this));
-				}.bind(this));
+				var self = this
+				// I think, here we need a new promise, since the buffer.save()
+				// one will most probably resolve... while the inner one is
+				// prone to failure
+				return new Promise(function(resolve, reject){
+					self.buffer.save().then(function(result) {
+						self.initiateUpload().then(
+							function() {
+								self.emitter.emit('saved');
+								if (atom.config.get('remote-edit-ni.uploadOptions.closeOnUpload'))
+									self.host.close();
+								resolve()
+							},
+							function(err) {
+								self.buffer.append("\n")
+								reject(err)
+							}
+						)
+					})
+				})
+
 			}
 
 			saveAs(filePath) {
@@ -218,9 +232,10 @@ module.exports =
 						},
 						callback => {
 							// Resolve only after we write the file on the remote
-							self.host.writeFile(self.localFile, () => {
-								resolve()
-								callback(null)
+							// and only if the write was successfull
+							self.host.writeFile(self.localFile, (err) => {
+								if (!err) resolve()
+								callback(err)
 							});
 						}
 					], err => {
@@ -240,6 +255,10 @@ module.exports =
 									password: result
 								});
 							});
+
+						} else if (err != null) {
+							console.log("Rejecting!")
+							reject(err)
 						}
 					});
 				})

--- a/lib/model/sftp-host.coffee
+++ b/lib/model/sftp-host.coffee
@@ -192,7 +192,7 @@ module.exports =
           callback()
       ], (err) =>
         if err?
-          @emitter.emit('info', {message: "Error occured when writing remote file sftp://#{@username}@#{@hostname}:#{@port}#{localFile.remoteFile.path}", type: 'error'})
+          @emitter.emit('info', {message: "Error occured when writing remote file sftp://#{@username}@#{@hostname}:#{@port}#{localFile.remoteFile.path}<br/>#{err}", type: 'error'})
           console.error err if err?
         else
           @emitter.emit('info', {message: "Successfully wrote remote file sftp://#{@username}@#{@hostname}:#{@port}#{localFile.remoteFile.path}", type: 'success'})


### PR DESCRIPTION
Hi,

I looked a bit on how errors are being handled and found out few things:

- Transport layer errors are handled within the individual host implementation (ftp or sftp) rather than in the module that initiates the connection. This makes sense if you think that different implementation might have to deal with different errors
-  Emitter is used to notify the user of any errors during saving files
-  The "blue dot" on the tab (save indicator) is misleading, since our plugin saves two times: (1) locally in the tmp folder and (2): uploading on the remote. As is currently the save indicator updates after a local save and does not change back if the remote upload fails (this PR fixes this)
-  Error handling on save() was a bit wrong... there are two async operations that both must succeed for the save to be complete. This PR fixes this by introducing a parent/wrapper Promise that will only succeed if both local and remote save work as expected
- The upload method was never rejecting/failing the promise! and was ignoring errors from the SSH `writeFile` method. This is now being handled
- Error messages were a bit vague (user side, console was detailed), trying to fix this by appending the specific error message to the popup/emitter

This has been partly tested with a local connection and lock filesystem permissions (to trigger errors). It should be contributing towards a more stable plugin, issue (#17) but I think we should leave the issue open.

Let me know what you think about this PR and if you see space for quick improvements