### PR TITLE
add platform cache folders

### DIFF
--- a/lib/view/files-view.coffee
+++ b/lib/view/files-view.coffee
@@ -17,6 +17,7 @@ _ = require 'underscore-plus'
 mkdirp = require 'mkdirp'
 moment = require 'moment'
 upath = require 'upath'
+pfolders = require 'platform-folders'
 
 module.exports =
   class FilesView extends View
@@ -257,7 +258,7 @@ module.exports =
     getDefaultSaveDirForHostAndFile: (file, callback) ->
       async.waterfall([
         (callback) ->
-          fs.realpath(os.tmpdir(), callback)
+          fs.realpath(pfolders.getCacheFolder(), callback)
         (tmpDir, callback) ->
           tmpDir = tmpDir + path.sep + "remote-edit"
           fs.mkdir(tmpDir, ((err) ->

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "mkdirp": "~0.5.1",
     "upath": "~0.1.6",
     "temp": ">=0.8.3",
-    "rwlock": ">=5.0.0"
+    "rwlock": ">=5.0.0",
+    "platform-folders": ">=0.2.6"
   },
   "optionalDependencies": {
     "keytar": "~3.0.0"


### PR DESCRIPTION
Using /tmp in linux where reboots purge the tmpDir was bad.

This also includes the proper dirs for windows.

To not reinvent the wheel, platform-folders is an added dep.