### PR TITLE
[filter] Bug fixes + Open item on enter if only one item is displayed

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ Show open (downloaded) remote files.
 Give focus to the remote-edit file browser. This allows you to navigate with
 keyboard (up/down/enter/backspace/escape)
 
+- <kbd>Alt+r l</kbd> / <kbd>&#8984;+r l</kbd> -
+Give focus to the remote-edit file browser's filter bar which can also be used
+for navigation to a different folder
+
 - <kbd>Alt+r d</kbd> / <kbd>&#8984;+r d</kbd> -
 Disconnect all open server connections. Server connections are normally kept open to improve save and browse performance.
 

--- a/keymaps/remote-edit.cson
+++ b/keymaps/remote-edit.cson
@@ -12,6 +12,7 @@
   'cmd-r o': 'remote-edit:show-open-files'
   'cmd-r v': 'remote-edit:toggle-files-view'
   'cmd-r f': 'filesview:list-focus'
+  'cmd-r l': 'filesview:list-filter-focus'
   'cmd-r m': 'remote-edit:browse-more'
   'cmd-r d': 'remote-edit:close-all-connections'
 
@@ -20,6 +21,7 @@
   'alt-r o': 'remote-edit:show-open-files'
   'alt-r v': 'remote-edit:toggle-files-view'
   'alt-r f': 'filesview:list-focus'
+  'alt-r l': 'filesview:list-filter-focus'
   'alt-r m': 'remote-edit:browse-more'
   'alt-r d': 'remote-edit:close-all-connections'
 

--- a/lib/view/files-view.coffee
+++ b/lib/view/files-view.coffee
@@ -105,8 +105,8 @@ module.exports =
       if @filter.val().length > 0
         @list.find('li').each (index, item) =>
           # Escape regex
-          re = @filter.val().replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-          if !$(item).text().match(re)
+          # re = @filter.val().replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+          if !$(item).text().includes(@filter.val())
             $(item).addClass('hidden')
           else
             $(item).removeClass('hidden')

--- a/lib/view/files-view.coffee
+++ b/lib/view/files-view.coffee
@@ -65,11 +65,12 @@ module.exports =
       listedItems = @getFilteredItems()
 
       # If only one item is in the list, open it
-      if listedItems.length  == 1
-        @confirmed(listedItems.first().data('select-list-item'))
-
-      # Looks like a path, treat it as a chdir
-      else if @filter.val().indexOf("/") > -1
+      # if listedItems.length  == 1
+      #   @confirmed(listedItems.first().data('select-list-item'))
+      #
+      # # Looks like a path, treat it as a chdir
+      # else
+      if @filter.val().indexOf("/") > -1
 
         toOpen = @filter.val()
         if @filter.val()[0] == "." or @filter.val()[0] != "/"
@@ -83,7 +84,7 @@ module.exports =
             @deselect()
         )
       # Jump to the list
-      else
+      else if @getFilteredItems().length > 0
         @selectInitialItem()
         @list.focus()
 
@@ -103,7 +104,9 @@ module.exports =
       # Hide the elements that do not match the filter's value
       if @filter.val().length > 0
         @list.find('li').each (index, item) =>
-          if ! $(item).text().match(@filter.val())
+          # Escape regex
+          re = @filter.val().replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+          if !$(item).text().match(re)
             $(item).addClass('hidden')
           else
             $(item).removeClass('hidden')
@@ -497,7 +500,7 @@ module.exports =
 
     listEnter: =>
       item = @getSelectedItem()
-      if !item
+      if item.length == 0
         return
       @confirmed(item.data('select-list-item'))
       @list.focus()


### PR DESCRIPTION
Hi @newinnovations - sry for disappearing but I was in the middle of changing jobs...

I tried to reproduce #30 but I couldn't. However, in the process I found few a minor bug with the filter function on files-view panel. When the file list is filtered, up/down arrow selection was not working as expected: it was selecting the hidden files in the background instead of only selecting what is displayed.

Along the way of fixing this, I added 2 small features:

1. <kbd>Alt+r l</kbd> (that is L) will give focus to the filter/location bar
2. Other than serving as a filter, this could be used as a location navigation, so hitting <kbd>enter</kbd> would take you to the typed path (ex: "/var/log" + enter will load the /var/log folder in the files-view). Now, if a single file/entry is displayed after filtering, enter will actually open that file or folder (using `@confirmed()` method)

Demo (one of my first gifs so not really a master-piece...):

![demo](https://user-images.githubusercontent.com/796204/44618844-93da5700-a875-11e8-8b8a-d942d72adc1b.gif)
