### PR TITLE
[feature] Checking remote file for changes

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -39,6 +39,18 @@ module.exports =
                         but will introduce the overhead of reconnecting on every save"""
           type: 'boolean'
           default: false
+        fileModifiedCheckInterval:
+          title: '[EXPERIMENTAL] Check remote file for changes and auto-refresh'
+          description: """Periodically check all the open files (using stat and
+                       mtime). When a change is detected, if the local file is
+                       not modified, it will automatically reload the tab. If
+                       both local and remote files are changed, then a panel will
+                       be displayed for the user to choose action (reload or ignore)
+                       A value of 0 disables checking (value in seconds).
+                       NOTE: It applies ONLY to newly opened tabs
+                       """
+          type: 'integer'
+          default: 0
     notifications:
       title: 'Display notifications'
       type: 'boolean'

--- a/lib/model/remote-edit-editor.js
+++ b/lib/model/remote-edit-editor.js
@@ -6,6 +6,8 @@
  */
 let Editor, RemoteEditEditor;
 const path = require('path');
+const fs = require("fs");
+
 
 let resourcePath = atom.config.resourcePath;
 if (!resourcePath) {
@@ -72,6 +74,187 @@ module.exports =
 				if (!this.localFile.host && params.host) {
 					this.localFile.host = params.host
 				}
+
+				this.startRefresh()
+			}
+
+			/**
+			 * Init a banner (div) that can be attached on the top of the
+			 * atom-text-editor. This is a bit of hack but we need a way to
+			 * display messages per-file
+			 */
+			_initBanner() {
+				this.banner = document.createElement("div");
+				this.banner.className = "text-editor-banner";
+				this.banner.style.width = "100%";
+				this.banner.style.padding = "10px";
+				this.banner.style.zIndex = 10;
+				this.banner.style.position = "absolute";
+				this.banner.style.top = "auto";
+				this.banner.style.left = "auto";
+				this.banner.style.bottom = "auto";
+				this.banner.style.right = "auto";
+				let self = this;
+				this.editorObserver = new MutationObserver(
+					(mutationsList, observer) => {
+						for(let mutation of mutationsList) {
+							if (mutation.type != 'attributes')
+								continue;
+							if (mutation.attributeName != "style")
+								continue;
+
+							// Sync display!
+							let editor = self.getElement()
+							if (!editor || !self.banner)
+								continue;
+							self.banner.style.display = editor.style.display;
+							let height = self.banner.offsetHeight;
+							editor.firstChild.style.top = height + "px";
+						}
+					}
+				);
+
+			}
+
+			/**
+			 * Reload the buffer from the remote file.
+			 */
+			reload(final_callback) {
+				let self = this;
+
+				async.waterfall([
+				  (callback) => {
+					  self.host.getFile(self.localFile, callback);
+				  },
+				  (localFile, callback) => {
+					  self.getBuffer().reload();
+					  final_callback();
+				  }
+				])
+			}
+
+			hideBanner() {
+				this.banner.style.display = "none";
+				while (this.banner.firstChild) {
+				    this.banner.removeChild(this.banner.firstChild);
+				}
+				this.getElement().firstChild.style.top = 0;
+				this.editorObserver.disconnect();
+			}
+
+			/**
+			 * Given a DOM element, attach it to this.banner and display it
+			 */
+			displayBanner(element) {
+				let editorElement = this.getElement();
+				let parentNode = editorElement.parentNode;
+				if (!this.banner)
+					this._initBanner();
+					// Attach observer so we know when the banner should hide
+					this.editorObserver.observe(editorElement, {attributes: true});
+
+				// If on other tab, this should be hidden
+				this.banner.style.display = editorElement.style.display;
+				this.banner.appendChild(element);
+				parentNode.insertBefore(this.banner, parentNode.firstChild);
+				let height = this.banner.offsetHeight;
+				editorElement.firstChild.style.top = height + "px";
+			}
+
+			/**
+			 * Start checking the remote file periodically. If the interval is
+			 * less or eq to 0 then checking is aborted
+			 */
+			startRefresh() {
+				let interval = atom.config.get(
+					'remote-edit-ni.uploadOptions.fileModifiedCheckInterval'
+				);
+				if (interval <= 0)
+					return;
+
+				interval = interval * 1000;
+				let self = this;
+				this.checkTimer = setInterval(() => {self.checkRemote()}, interval);
+			}
+
+			displayFileModifiedBanner() {
+				let self = this;
+				let top = document.createElement("div");
+				let msg = document.createElement("div");
+				let actions = document.createElement("div");
+				top.appendChild(msg);
+				top.appendChild(actions);
+				msg.appendChild(document.createTextNode(
+					"Both the local and the remote file has been modified. " +
+					"Choose action (with reload you will lose the local changes):"
+				));
+
+				let ignore = document.createElement("button");
+				ignore.className = "inline-block btn";
+				ignore.innerHTML = "Ignore";
+				ignore.onclick = function() {
+					self.startRefresh();
+					self.hideBanner();
+				}
+
+				let reload = document.createElement("button");
+				reload.className = "inline-block btn";
+				reload.innerHTML = "Reload";
+				reload.onclick = function() {
+				  async.waterfall([
+					(callback) => {
+						self.reload(callback);
+					},
+					(callback) => {
+						self.startRefresh();
+					  	self.hideBanner();
+						return;
+					}
+				  ])
+				}
+
+				actions.appendChild(ignore);
+				actions.appendChild(reload);
+
+				this.displayBanner(top);
+			}
+
+			checkRemote() {
+				if (async == null) {
+					async = require('async');
+				}
+
+				let self = this
+				async.waterfall([
+					callback => {
+						if (!this.host.isConnected()) {
+							this.host.connect(callback, {});
+						} else {
+							callback();
+						}
+					},
+					callback => {
+						this.host.updateLastModified(this.localFile, callback);
+					},
+					callback => {
+						if (!this.localFile.remoteFile.needsRefresh()) {
+							return callback(null);
+						}
+						clearInterval(this.checkTimer);
+						this.checkTimer = null
+
+						if (!this.isModified()) {
+							this.reload(() => {
+  		  					  self.startRefresh();
+							});
+							return;
+						}
+
+						this.displayFileModifiedBanner();
+
+					}
+				])
+
 			}
 
 			copy() {
@@ -84,6 +267,7 @@ module.exports =
 				// Now do our clean-up
 				if (this.host)
 					this.host.close()
+				clearInterval(this.checkTimer)
 			}
 
 			getIconName() {
@@ -146,6 +330,8 @@ module.exports =
 								self.emitter.emit('saved');
 								if (atom.config.get('remote-edit-ni.uploadOptions.closeOnUpload'))
 									self.host.close();
+								if (!self.checkTimer)
+									self.startRefresh();
 								resolve()
 							},
 							function(err) {

--- a/lib/model/remote-edit-editor.js
+++ b/lib/model/remote-edit-editor.js
@@ -6,7 +6,6 @@
  */
 let Editor, RemoteEditEditor;
 const path = require('path');
-const fs = require("fs");
 
 
 let resourcePath = atom.config.resourcePath;

--- a/lib/model/remote-file.coffee
+++ b/lib/model/remote-file.coffee
@@ -12,9 +12,13 @@ module.exports =
       @dirName = Path.dirname(@path)
       if @name == '..'
         @path = Path.dirname(Path.dirname(@path))
+      @lastLoaded = @lastModified
 
     isHidden: (callback) ->
       callback(!(@name[0] == "." && @name.length > 2))
 
     serializeParams: ->
       {@path, @isFile, @isDir, @isLink, @size, @permissions, @lastModified}
+
+    needsRefresh: ->
+      @lastLoaded < @lastModified


### PR DESCRIPTION
Hi @newinnovations, it has been a while. Lately I am not using this plugin as much as I 'd like, however, I found sometime to write some code. 

This PR introduces auto-refresh by checking the remote file(s) every N seconds. N comes from config and by default is `0` (disabled). The check is based on lastLoad and lastModified attributes which in turn are based 100% on the remote fs.stat() (no time parameters from the local machine). The behaviour is as follows:

- If remote is modified and local file is not, automatically reload the tab's content to reflect the remote changes
- If both remote and local files are modified, display a banner (see later) to ask the user to either ignore the changes or reload the file. This is a bit more risky since reloading from the remote will result in losing the local buffer content and thus the user is responsible for choosing. If the user chooses to "Ignore" the changes, then the remote check is being disabled until the user saves the file. After saving, we restart the remote file check

Now, the banner mentioned above is a bit hackish. The reason is that atom notifications cannot do the job because (1) they are not persistent and (2) they float which means the notification might be for another tab the user doesn't see currently. 

Being a bit lazy, I am just adding a new div on top of the atom-editor element. Each editor is associated with its own banner (ie banner not shared between editors). Furthermore, the banner has not been styled too much and might look a bit funny:

![image](https://user-images.githubusercontent.com/796204/68127543-c45c5d00-ff1e-11e9-876d-192e7010be06.png)


Caveats:

- This was only tested _without_ the "Close connection after every upload" option (ie tested only with persistent connections)
- Tested with 3-4 files open at the same time. It might misbehave with tens of them open (we might want to consider connections to be shared amongst tabs in the future)
- I have tested few scenarios (like conflict happening when the user is on another tab) but more testing is needed, thus option flagged as experimental